### PR TITLE
Ignore extra columns at end of MRC data lines

### DIFF
--- a/zerg.py
+++ b/zerg.py
@@ -175,7 +175,7 @@ class ErgParser :
         if not self.endOfSection( line ) :
             #print '%s' % line
             try :
-                mins, percent = map( float, line.split() )
+                mins, percent = map( float, line.split()[0:2] )
                 self.data.append( ( mins, percent ) )
             except :
                 pass


### PR DESCRIPTION
This patch ignores extra columns at the end of data lines. Some MRC files seem to have comments after the time and percentage. This fix prevents those lines from being skipped.